### PR TITLE
Fixed error when fetching metadata on the latest version.

### DIFF
--- a/11matt556-ReusableMetadata.csproj
+++ b/11matt556-ReusableMetadata.csproj
@@ -47,15 +47,16 @@
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\HarmonyX.2.7.0\lib\net45\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.10.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\HarmonyX.2.10.0\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\Assembly-CSharp.dll</HintPath>
+      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.34.28524-r.0\lib\net45\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="BepInEx, Version=5.4.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\BepInEx.BaseLib.5.4.17\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="BepInEx, Version=5.4.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\BepInEx.BaseLib.5.4.21\lib\net35\BepInEx.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
@@ -68,16 +69,13 @@
     <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="MonoMod.RuntimeDetour, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\MonoMod.RuntimeDetour.21.12.13.1\lib\net452\MonoMod.RuntimeDetour.dll</HintPath>
+    <Reference Include="MonoMod.RuntimeDetour, Version=22.3.23.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\MonoMod.RuntimeDetour.22.3.23.4\lib\net452\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
-    <Reference Include="MonoMod.Utils, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\MonoMod.Utils.21.12.13.1\lib\net452\MonoMod.Utils.dll</HintPath>
+    <Reference Include="MonoMod.Utils, Version=22.5.1.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\MonoMod.Utils.22.5.1.1\lib\net452\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.dll</HintPath>
     </Reference>
@@ -150,9 +148,6 @@
     <Reference Include="UnityEngine.LocalizationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.LocalizationModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\UnityEngine.Networking.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
@@ -176,9 +171,6 @@
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.SharedInternalsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.SpatialTracking, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\UnityEngine.SpatialTracking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.SpriteMaskModule.dll</HintPath>
@@ -213,14 +205,11 @@
     <Reference Include="UnityEngine.TilemapModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.TilemapModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.Timeline, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\UnityEngine.Timeline.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine.TLSModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.TLSModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.28.21219-r.0\lib\net45\UnityEngine.UI.dll</HintPath>
+      <HintPath>packages\DysonSphereProgram.GameLibs.0.10.34.28524-r.0\lib\net45\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\UnityEngine.Modules.2022.1.17\lib\net45\UnityEngine.UIElementsModule.dll</HintPath>
@@ -293,11 +282,11 @@ copy /Y "$(TargetPath)" "$(ProjectDir)/ThunderstorePackage"
 copy /Y "$(ProjectDir)/README.md" "$(ProjectDir)/ThunderstorePackage"
 copy /Y "$(ProjectDir)/manifest.json" "$(ProjectDir)/ThunderstorePackage"</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="packages\BepInEx.Core.5.4.17\build\BepInEx.Core.targets" Condition="Exists('packages\BepInEx.Core.5.4.17\build\BepInEx.Core.targets')" />
+  <Import Project="packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets" Condition="Exists('packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\BepInEx.Core.5.4.17\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BepInEx.Core.5.4.17\build\BepInEx.Core.targets'))" />
+    <Error Condition="!Exists('packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets'))" />
   </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Let me know if you have suggestions or issues at https://github.com/11matt556/DS
 
 ## Change Log
 
+- Version 1.0.8:
+	- Bugfix: Fixed issue with plugin not loading on the latest version. [Error  :  HarmonyX] Failed to patch long PropertySystem::GetItemTotalProperty(int itemId): System.Exception: Cannot assign method return type System.Int64 to __result type System.Int32 for method long PropertySystem::GetItemTotalProperty(int itemId)
+
 - Version 1.0.7:
 	- Bugfix: Fixed enableSandboxCheat config option
 	- Feature: New config option, sandboxMultiplier. Use this to specify desired metadata multiplier in sandbox mode when enableSandboxCheat=true.

--- a/ReusableMetadataPlugin.cs
+++ b/ReusableMetadataPlugin.cs
@@ -121,7 +121,7 @@ namespace ReusableMetadata
             {
                 ClusterPropertyData clusterPropertyData = __instance.propertyDatas[i];
 
-                long production = clusterPropertyData.GetItemProduction(itemId);
+                int production = clusterPropertyData.GetItemProduction(itemId);
 
                 if (ReusableMetadataPlugin.useVerboseLogging.Value)
                 {

--- a/ReusableMetadataPlugin.cs
+++ b/ReusableMetadataPlugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using HarmonyLib;
 using BepInEx.Logging;
 using BepInEx.Configuration;
@@ -35,8 +35,6 @@ In Game Descriptions
 "Current Available Amount" = "Current immediately instantiable metadata. You can't instantiate metadata contributed by the current cluster address, so it equals to the remaining amount minus contribution from current cluster address"
 
 */
-// TODO: Update UI tooltips to match mod behaviour
-// TODO: See if there is a way to fix potentially inaccurate "Instantiation" stats that can occur when instantiating without saving. This does not seem to impact the available metadata calculations.
 
 namespace ReusableMetadata
 {
@@ -45,7 +43,8 @@ namespace ReusableMetadata
     {
         public const string pluginGuid = "11matt556.dysonsphereprogram.ReusableMetadata";
         public const string pluginName = "Reusable Metadata";
-        public const string pluginVersion = "1.0.7";
+        public const string pluginVersion = "1.0.8";
+
         public static ManualLogSource logger;
         public static ConfigEntry<bool> useHighestProductionOnly;
         public static ConfigEntry<bool> useVerboseLogging;
@@ -57,9 +56,7 @@ namespace ReusableMetadata
         {
             logger = Logger;
             topSeedForItem = new Dictionary<int, long>();
-            Harmony harmony = new Harmony(pluginGuid);
 
-            // Why is this needed here? Adding to dict later does not work...
             topSeedForItem.Add(6001, -1);
             topSeedForItem.Add(6002, -1);
             topSeedForItem.Add(6003, -1);
@@ -67,13 +64,38 @@ namespace ReusableMetadata
             topSeedForItem.Add(6005, -1);
             topSeedForItem.Add(6006, -1);
 
-            useHighestProductionOnly = Config.Bind("Behaviour", "useHighestProductionOnly", false, "When True, only metadata contributions from your highest production cluster will be available. Metadata can be thought of as a 'high score' with this setting enabled. When false, Metadata production is unchanged unchanged from Vanilla.");
-            useVerboseLogging = Config.Bind("Debugging", "verboseLogging", false, "For debugging.");
-            useSandboxCheat = Config.Bind("Debugging", "enableSandboxCheat", false, "Sets sandbox metadata multiplier to sandboxMultiplier. Use at your own risk.");
-            sandboxMultiplier = Config.Bind("Debugging", "sandboxMultiplier", 1f, "Sets Sandbox Metadata multiplier to the entered value. 1 = 100%");
+            useHighestProductionOnly = Config.Bind(
+                "Behaviour",
+                "useHighestProductionOnly",
+                false,
+                "When true, only metadata contributions from your highest production cluster will be available. Metadata can be thought of as a high score with this setting enabled. When false, metadata production is summed across clusters."
+            );
 
+            useVerboseLogging = Config.Bind(
+                "Debugging",
+                "verboseLogging",
+                false,
+                "For debugging."
+            );
+
+            useSandboxCheat = Config.Bind(
+                "Debugging",
+                "enableSandboxCheat",
+                false,
+                "Sets sandbox metadata multiplier to sandboxMultiplier. Use at your own risk."
+            );
+
+            sandboxMultiplier = Config.Bind(
+                "Debugging",
+                "sandboxMultiplier",
+                1f,
+                "Sets sandbox metadata multiplier to the entered value. 1 = 100%."
+            );
+
+            Harmony harmony = new Harmony(pluginGuid);
             harmony.PatchAll();
-            logger.LogInfo(pluginName + " " + pluginVersion + " " + "Patch successful");
+
+            logger.LogInfo(pluginName + " " + pluginVersion + " Patch successful");
         }
     }
 
@@ -82,26 +104,33 @@ namespace ReusableMetadata
     {
         [HarmonyPatch(typeof(PropertySystem), nameof(PropertySystem.GetItemTotalProperty))]
         [HarmonyPrefix]
-        public static bool GetItemTotalProperty_Patch(int itemId, PropertySystem __instance, ref int __result)
+        public static bool GetItemTotalProperty_Patch(int itemId, PropertySystem __instance, ref long __result)
         {
-            //GetItemTotalProperty corresponds to the large 'Amount' number at the very top of the Metadata panel
+            // GetItemTotalProperty corresponds to the large "Amount" number at the top of the Metadata panel.
 
-            //GameMain.history.GetPropertyItemComsumption(itemId); 
             long currentClusterSeedKey = GameMain.data.GetClusterSeedKey();
-            int productionHighScore = 0;
-            int netTotalMetadata = 0;
+            long productionHighScore = 0L;
+            long netTotalMetadata = 0L;
 
             if (ReusableMetadataPlugin.useVerboseLogging.Value)
+            {
                 ReusableMetadataPlugin.logger.LogInfo("Current Seed " + currentClusterSeedKey);
-
+            }
 
             for (int i = 0; i < __instance.propertyDatas.Count; i++)
             {
                 ClusterPropertyData clusterPropertyData = __instance.propertyDatas[i];
-                if (ReusableMetadataPlugin.useVerboseLogging.Value)
-                    ReusableMetadataPlugin.logger.LogInfo("GetItemTotalProperty_Patch ID=" + itemId + " production=" + clusterPropertyData.GetItemProduction(itemId) + " seed=" + clusterPropertyData.seedKey);
 
-                int production = clusterPropertyData.GetItemProduction(itemId);
+                long production = clusterPropertyData.GetItemProduction(itemId);
+
+                if (ReusableMetadataPlugin.useVerboseLogging.Value)
+                {
+                    ReusableMetadataPlugin.logger.LogInfo(
+                        "GetItemTotalProperty_Patch ID=" + itemId +
+                        " production=" + production +
+                        " seed=" + clusterPropertyData.seedKey
+                    );
+                }
 
                 // If useHighestProductionOnly is set, find the highest metadata value out of all clusters and ignore the others.
                 if (ReusableMetadataPlugin.useHighestProductionOnly.Value)
@@ -113,76 +142,78 @@ namespace ReusableMetadata
                         ReusableMetadataPlugin.topSeedForItem[itemId] = clusterPropertyData.seedKey;
                     }
                 }
-                // Otherwise, just add up the production of all clusters. This is what the Vanilla game does.
                 else
                 {
-                    if (ReusableMetadataPlugin.useVerboseLogging.Value)
-                        ReusableMetadataPlugin.logger.LogInfo("GetItemTotalProperty_Patch ID=" + itemId + " Production=" + production + " seed=" + clusterPropertyData.seedKey);
+                    // Otherwise, add up production from all clusters.
                     netTotalMetadata += production;
                 }
             }
 
             if (ReusableMetadataPlugin.useVerboseLogging.Value)
-                ReusableMetadataPlugin.logger.LogInfo("GetItemTotalProperty_Patch ID=" + itemId + " Calculated Total=" + netTotalMetadata);
+            {
+                ReusableMetadataPlugin.logger.LogInfo(
+                    "GetItemTotalProperty_Patch ID=" + itemId +
+                    " Calculated Total=" + netTotalMetadata
+                );
+            }
 
             __result = netTotalMetadata;
-
             return false;
         }
-
         [HarmonyPatch(
-            typeof(PropertySystem),
-            nameof(PropertySystem.GetItemAvaliableProperty),
-            new[]
-            {
-                typeof(long),
-                typeof(int)
-            }
-            )
-         ]
+    typeof(PropertySystem),
+    nameof(PropertySystem.GetItemAvaliableProperty),
+    new[]
+    {
+        typeof(long),
+        typeof(int)
+    }
+)]
         [HarmonyPrefix]
-        public static bool GetItemAvaliableProperty_Patch(long seedKey, int itemId, PropertySystem __instance, ref int __result)
+        public static bool GetItemAvaliableProperty_Patch(long seedKey, int itemId, PropertySystem __instance, ref long __result)
         {
-            //ClusterPropertyData clusterData = __instance.GetClusterData(seedKey);
-            int availableMetadata = __instance.GetItemTotalProperty(itemId); //Start with all metadata
-            if (ReusableMetadataPlugin.useVerboseLogging.Value)
-                ReusableMetadataPlugin.logger.LogInfo($"GetItemAvaliableProperty_Patch_Start={availableMetadata} ID={itemId} ");
+            long availableMetadata = __instance.GetItemTotalProperty(itemId);
 
-            // Sanity check to make sure we are acting on the current seed.
+            if (ReusableMetadataPlugin.useVerboseLogging.Value)
+            {
+                ReusableMetadataPlugin.logger.LogInfo(
+                    $"GetItemAvaliableProperty_Patch_Start={availableMetadata} ID={itemId}"
+                );
+            }
+
             if (GameMain.data.GetClusterSeedKey() == seedKey)
             {
-                // Only subtract metadata consumed of current seed, not all seeds. This one line is really the main point of this whole mod...
-                // Important thing to remember! 
-                // GameMain.history.GetPropertyItemComsumption reads the game data itself. It will OVERRULE whatever is in the property file
-                // PropertySystem.GetItemConsumption reads from the property file itself! 
-                // I use GameMain.history here because it seems to prtevent the vanilla bug where metadata is lost when realizing and exiting without saving.
-
-                //availableMetadata -= ReusableMetadataPlugin.gameSaveConsTextDict[itemId];
                 availableMetadata -= GameMain.history.GetPropertyItemComsumption(itemId);
-                //availableMetadata -= __instance.GetItemConsumption(seedKey, itemId);
 
                 if (ReusableMetadataPlugin.useVerboseLogging.Value)
                 {
-                    ReusableMetadataPlugin.logger.LogInfo($"GetItemAvaliableProperty_Patch ID={itemId} PropertySystem.GetItemConsumption={__instance.GetItemConsumption(seedKey, itemId)} seed={seedKey}");
-                    ReusableMetadataPlugin.logger.LogInfo($"GetItemAvaliableProperty_Patch ID={itemId} GameMain.history.GetPropertyItemComsumption={GameMain.history.GetPropertyItemComsumption(itemId)} seed={seedKey}");
+                    ReusableMetadataPlugin.logger.LogInfo(
+                        $"GetItemAvaliableProperty_Patch ID={itemId} PropertySystem.GetItemConsumption={__instance.GetItemConsumption(seedKey, itemId)} seed={seedKey}"
+                    );
+
+                    ReusableMetadataPlugin.logger.LogInfo(
+                        $"GetItemAvaliableProperty_Patch ID={itemId} GameMain.history.GetPropertyItemComsumption={GameMain.history.GetPropertyItemComsumption(itemId)} seed={seedKey}"
+                    );
                 }
 
-                // Make sure we can't spend metadata from the current seed.
                 if (ReusableMetadataPlugin.useHighestProductionOnly.Value && seedKey != ReusableMetadataPlugin.topSeedForItem[itemId])
                 {
-                    // Do nothing because we did not actually contribute any metadata to the total.
+                    // This seed did not contribute to the total.
                 }
                 else
                 {
-                    // This production contributed to the total metadata and so needs to be removed from the available metadata.
                     availableMetadata -= __instance.GetItemProduction(seedKey, itemId);
                 }
             }
 
-            if (ReusableMetadataPlugin.useVerboseLogging.Value)
-                ReusableMetadataPlugin.logger.LogInfo($"GetItemAvaliableProperty_Patch_Result={__result} ID={itemId} ");
-
             __result = availableMetadata;
+
+            if (ReusableMetadataPlugin.useVerboseLogging.Value)
+            {
+                ReusableMetadataPlugin.logger.LogInfo(
+                    $"GetItemAvaliableProperty_Patch_Result={__result} ID={itemId}"
+                );
+            }
 
             return false;
         }
@@ -192,8 +223,8 @@ namespace ReusableMetadata
         [HarmonyPostfix]
         public static void GameScenarioLogic_GameTick_Patch(long time, GameScenarioLogic __instance)
         {
-            // Make the metadata logic tick happen in sandbox mode
-            if (__instance.gameData.gameDesc.isSandboxMode && ReusableMetadataPlugin.useSandboxCheat.Value == true)
+            // Make metadata logic tick happen in sandbox mode.
+            if (__instance.gameData.gameDesc.isSandboxMode && ReusableMetadataPlugin.useSandboxCheat.Value)
             {
                 __instance.propertyLogic.GameTick(time);
             }
@@ -204,8 +235,8 @@ namespace ReusableMetadata
         [HarmonyPostfix]
         public static void GameMain_Begin_Patch(GameMain __instance)
         {
-            // If we are in sandbox mode and not using the cheat, reset all metadata production to 0
-            if (DSPGame.GameDesc.isSandboxMode && ReusableMetadataPlugin.useSandboxCheat.Value == false)
+            // If in sandbox mode and not using the cheat, reset all metadata production to 0.
+            if (DSPGame.GameDesc.isSandboxMode && !ReusableMetadataPlugin.useSandboxCheat.Value)
             {
                 for (int itemId = 6001; itemId <= 6006; itemId++)
                 {
@@ -213,24 +244,21 @@ namespace ReusableMetadata
                     DSPGame.propertySystem.SetItemProduction(DSPGame.GameDesc.seedKey64, itemId, 0);
                 }
             }
-
         }
-
 
         [HarmonyPatch(typeof(PropertySystem))]
         [HarmonyPatch("GetItemProduction")]
         [HarmonyPostfix]
-        public static void PropertySystem_GetItemProduction_Patch(long seedKey,int itemId, PropertySystem __instance, ref int __result)
+        public static void PropertySystem_GetItemProduction_Patch(long seedKey, int itemId, PropertySystem __instance, ref int __result)
         {
             if (GameMain.gameScenario != null && seedKey == GameMain.data.GetClusterSeedKey())
             {
                 int currentGameContribution = GameMain.history.GetPropertyItemProduction(itemId);
-                // Current game contribution cannot be greater than the current cluster, but this can happen if the property file is deleted.
-                // Fix this by setting the cluster contribution to equal the game contribution
-                // Note: This is technically a vanilla bug
-                if (__result < currentGameContribution )
+
+                // Current game contribution cannot be greater than current cluster contribution.
+                // If the property file is deleted, this can happen. Fix by syncing cluster contribution.
+                if (__result < currentGameContribution)
                 {
-                    //__instance.SetItemProduction(itemId, currentGameContribution);
                     __instance.SetItemProduction(seedKey, itemId, currentGameContribution);
                     GameMain.history.SetPropertyItemProduction(itemId, currentGameContribution);
                     __result = currentGameContribution;
@@ -243,66 +271,84 @@ namespace ReusableMetadata
         [HarmonyPostfix]
         public static void UIPropertyEntry_UpdateUIElements_Patch(UIPropertyEntry __instance)
         {
-            // Update Metadata panel to display custom multiplier and allow button to be used in sandbox mode.
+            // Update Metadata panel to display custom multiplier and allow button use in sandbox mode.
             if (DSPGame.GameDesc.isSandboxMode && ReusableMetadataPlugin.useSandboxCheat.Value)
             {
-                int avaliableProperty = DSPGame.propertySystem.GetItemAvaliableProperty(GameMain.data.GetClusterSeedKey(), __instance.itemId);
+                long avaliableProperty = DSPGame.propertySystem.GetItemAvaliableProperty(
+                    GameMain.data.GetClusterSeedKey(),
+                    __instance.itemId
+                );
+
                 __instance.realizeButton.button.interactable = GameMain.mainPlayer.isAlive && avaliableProperty > 0;
-                __instance.productionRateText1.text = __instance.productionRateText0.text = string.Format("( x {0:0%} )", ReusableMetadataPlugin.sandboxMultiplier.Value);
+                __instance.productionRateText1.text = __instance.productionRateText0.text =
+                    string.Format("( x {0:0%} )", ReusableMetadataPlugin.sandboxMultiplier.Value);
             }
         }
-        
+
         [HarmonyPatch(
-        typeof(PropertyLogic),
-        nameof(PropertyLogic.UpdateProduction)
-        )
-        ]
+            typeof(PropertyLogic),
+            nameof(PropertyLogic.UpdateProduction)
+        )]
         [HarmonyPrefix]
         public static bool PropertyLogic_UpdateProduction_Patch(PropertyLogic __instance)
         {
-
             FactoryProductionStat[] factoryStatPool = __instance.gameData.statistics.production.factoryStatPool;
             int factoryCount = __instance.gameData.factoryCount;
-            ClusterPropertyData clusterData = __instance.propertySystem.GetClusterData(__instance.gameData.GetClusterSeedKey());
+
+            ClusterPropertyData clusterData = __instance.propertySystem.GetClusterData(
+                __instance.gameData.GetClusterSeedKey()
+            );
+
             ClusterPropertyData propertyData = __instance.gameData.history.propertyData;
-            //ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch");
+
             foreach (int productId in PropertySystem.productIds)
             {
                 int itemProduction1 = propertyData.GetItemProduction(productId);
                 int itemProduction2 = clusterData.GetItemProduction(productId);
 
-                //ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch itemProduction1={itemProduction1}");
-                //ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch itemProduction2={itemProduction2}");
+                long num = 0L;
 
-                long num = 0;
                 for (int index = 0; index < factoryCount; ++index)
                 {
                     int productIndex = factoryStatPool[index].productIndices[productId];
-                    //ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch productIndex={productIndex}");
+
                     if (productIndex > 0)
                     {
-                        //ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch factoryStatPool[index].productPool[productIndex].total[3]={factoryStatPool[index].productPool[productIndex].total[3]}");
                         num += factoryStatPool[index].productPool[productIndex].total[3];
                     }
                 }
 
-                /* 
-                 * Just bodge a multiplier in here since manipulating minimalPropertyMultiplier with prefix and postfix was just asking for trouble.
-                 * Turns out changing minimalPropertyMultiplier can permanently change the multiplier value on save files, even after removing the mod.
-                */
-                float multiplier = 0;
-                if (ReusableMetadataPlugin.useSandboxCheat.Value && DSPGame.GameDesc.isSandboxMode) {
+                /*
+                 * Bodge multiplier here since manipulating minimalPropertyMultiplier with prefix/postfix can persist changes to save files.
+                 */
+                float multiplier;
+
+                if (ReusableMetadataPlugin.useSandboxCheat.Value && DSPGame.GameDesc.isSandboxMode)
+                {
                     multiplier = ReusableMetadataPlugin.sandboxMultiplier.Value;
                 }
-                else {
+                else
+                {
                     multiplier = __instance.gameData.history.minimalPropertyMultiplier;
                 }
 
-                int count = (int)((double)num * (double)multiplier / 60.0 + 0.001);
+                long calculatedCount = (long)((double)num * (double)multiplier / 60.0 + 0.001);
+
+                int count = calculatedCount > int.MaxValue
+                    ? int.MaxValue
+                    : calculatedCount < int.MinValue
+                        ? int.MinValue
+                        : (int)calculatedCount;
+
                 if (count > itemProduction1)
+                {
                     propertyData.SetItemProduction(productId, count);
+                }
+
                 if (count > itemProduction2)
+                {
                     clusterData.SetItemProduction(productId, count);
+                }
 
                 if (ReusableMetadataPlugin.useVerboseLogging.Value)
                 {
@@ -311,8 +357,8 @@ namespace ReusableMetadata
                     ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch minimalPropertyMultiplier={multiplier}");
                 }
             }
+
             return false;
         }
-        
     }
 }

--- a/ReusableMetadataPlugin.cs
+++ b/ReusableMetadataPlugin.cs
@@ -344,12 +344,7 @@ namespace ReusableMetadata
                 }
 
                 long calculatedCount = (long)((double)num * (double)multiplier / 60.0 + 0.001);
-
-                int count = calculatedCount > int.MaxValue
-                    ? int.MaxValue
-                    : calculatedCount < int.MinValue
-                        ? int.MinValue
-                        : (int)calculatedCount;
+                int count = (int)Mathf.Clamp(calculatedCount, int.MinValue, int.MaxValue);
 
                 if (count > itemProduction1)
                 {

--- a/ReusableMetadataPlugin.cs
+++ b/ReusableMetadataPlugin.cs
@@ -201,6 +201,7 @@ namespace ReusableMetadata
                     );
                 }
 
+                // Make sure we can't spend metadata from the current seed.
                 if (ReusableMetadataPlugin.useHighestProductionOnly.Value && seedKey != ReusableMetadataPlugin.topSeedForItem[itemId])
                 {
                     // This seed did not contribute to the total.
@@ -259,9 +260,8 @@ namespace ReusableMetadata
             if (GameMain.gameScenario != null && seedKey == GameMain.data.GetClusterSeedKey())
             {
                 int currentGameContribution = GameMain.history.GetPropertyItemProduction(itemId);
-
-                // Current game contribution cannot be greater than current cluster contribution.
-                // If the property file is deleted, this can happen. Fix by syncing cluster contribution.
+                // Deleting the property file can cause the current game contribution to exceed the cluster contribution
+                // Fix this by updating the cluster contribution to equal the game contribution.
                 if (__result < currentGameContribution)
                 {
                     __instance.SetItemProduction(seedKey, itemId, currentGameContribution);
@@ -305,7 +305,8 @@ namespace ReusableMetadata
             );
 
             ClusterPropertyData propertyData = __instance.gameData.history.propertyData;
-
+            if (ReusableMetadataPlugin.useVerboseLogging.Value)
+                ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch");
             foreach (int productId in PropertySystem.productIds)
             {
                 int itemProduction1 = propertyData.GetItemProduction(productId);
@@ -316,16 +317,21 @@ namespace ReusableMetadata
                 for (int index = 0; index < factoryCount; ++index)
                 {
                     int productIndex = factoryStatPool[index].productIndices[productId];
-
+                    if (ReusableMetadataPlugin.useVerboseLogging.Value)
+                        ReusableMetadataPlugin.logger.LogInfo($"PropertyLogic_UpdateProduction_Patch productIndex={productIndex}");
                     if (productIndex > 0)
                     {
+                        if (ReusableMetadataPlugin.useVerboseLogging.Value)
+                            ReusableMetadataPlugin.logger.LogDebug($"PropertyLogic_UpdateProduction_Patch factoryStatPool[index].productPool[productIndex].total[3]={factoryStatPool[index].productPool[productIndex].total[3]}");
                         num += factoryStatPool[index].productPool[productIndex].total[3];
                     }
                 }
 
-                /*
-                 * Bodge multiplier here since manipulating minimalPropertyMultiplier with prefix/postfix can persist changes to save files.
-                 */
+                /* 
+                 * Changing minimalPropertyMultiplier in prefix/postfix would be easier, but this will persist in save files, **even after the mod is removed**.
+                 * To avoid this, we reimplement the entirety of the UpdateProduction() function so we may use a multiplier of our choosing.
+                 * This is the safest way to pevent unexpected savefile modifications, but could be problematic if the vanilla game changes the production calculation formula in a future update.
+                */
                 float multiplier;
 
                 if (ReusableMetadataPlugin.useSandboxCheat.Value && DSPGame.GameDesc.isSandboxMode)

--- a/ReusableMetadataPlugin.cs
+++ b/ReusableMetadataPlugin.cs
@@ -183,6 +183,11 @@ namespace ReusableMetadata
 
             if (GameMain.data.GetClusterSeedKey() == seedKey)
             {
+                // Only subtract metadata consumed of current seed, not all seeds. This one line is really the main point of this whole mod...
+                // Important thing to remember! 
+                // GameMain.history.GetPropertyItemComsumption reads the game data itself. It will OVERRULE whatever is in the property file
+                // PropertySystem.GetItemConsumption reads from the property file itself! 
+                // I use GameMain.history here because it seems to prtevent the vanilla bug where metadata is lost when realizing and exiting without saving.
                 availableMetadata -= GameMain.history.GetPropertyItemComsumption(itemId);
 
                 if (ReusableMetadataPlugin.useVerboseLogging.Value)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ReusableMetadata",
-    "version_number": "1.0.7",
+    "version_number": "1.0.8",
     "website_url": "https://github.com/11matt556/DSP-ReusableMetadata",
     "description": "Allows metadata to be reused across multiple cluster seeds.",
     "dependencies": [

--- a/packages.config
+++ b/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BepInEx.BaseLib" version="5.4.17" targetFramework="net48" />
-  <package id="BepInEx.Core" version="5.4.17" targetFramework="net48" />
-  <package id="DysonSphereProgram.GameLibs" version="0.9.26.13026-r.0" targetFramework="net461" />
-  <package id="HarmonyX" version="2.7.0" targetFramework="net461" />
+  <package id="BepInEx.BaseLib" version="5.4.21" targetFramework="net48" />
+  <package id="BepInEx.Core" version="5.4.21" targetFramework="net48" />
+  <package id="DysonSphereProgram.GameLibs" version="0.10.34.28524-r.0" targetFramework="net48" />
+  <package id="HarmonyX" version="2.10.0" targetFramework="net48" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net461" />
-  <package id="MonoMod.RuntimeDetour" version="21.12.13.1" targetFramework="net461" />
-  <package id="MonoMod.Utils" version="21.12.13.1" targetFramework="net461" />
+  <package id="MonoMod.RuntimeDetour" version="22.3.23.4" targetFramework="net48" />
+  <package id="MonoMod.Utils" version="22.5.1.1" targetFramework="net48" />
   <package id="UnityEngine" version="5.6.1" targetFramework="net461" />
   <package id="UnityEngine.Modules" version="2022.1.17" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Fixed the below error:
[Error  :  HarmonyX] Failed to patch long PropertySystem::GetItemTotalProperty(int itemId): System.Exception: Cannot assign method return type System.Int64 to __result type System.Int32 for method long PropertySystem::GetItemTotalProperty(int itemId)
  at HarmonyLib.Public.Patching.HarmonyManipulator.EmitCallParameter (HarmonyLib.Internal.Util.ILEmitter il, System.Reflection.MethodBase original, System.Reflection.MethodInfo patch, System.Collections.Generic.Dictionary`2[TKey,TValue] variables, System.Boolean allowFirsParamPassthrough, Mono.Cecil.Cil.VariableDefinition& tmpObjectVar, System.Collections.Generic.List`1[HarmonyLib.Public.Patching.HarmonyManipulator+ArgumentBoxInfo]& tmpBoxVars) [0x003a4] in <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0
  at HarmonyLib.Public.Patching.HarmonyManipulator.WritePrefixes (HarmonyLib.Internal.Util.ILEmitter il, System.Reflection.MethodBase original, HarmonyLib.Internal.Util.ILEmitter+Label returnLabel, System.Collections.Generic.Dictionary`2[TKey,TValue] variables, System.Collections.Generic.ICollection`1[T] prefixes, System.Boolean debug) [0x00128] in <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0
  at HarmonyLib.Public.Patching.HarmonyManipulator.MakePatched (System.Reflection.MethodBase original, MonoMod.Cil.ILContext ctx, System.Collections.Generic.List`1[T] prefixes, System.Collections.Generic.List`1[T] postfixes, System.Collections.Generic.List`1[T] transpilers, System.Collections.Generic.List`1[T] finalizers, System.Collections.Generic.List`1[T] ilmanipulators, System.Boolean debug) [0x00192] in <7f26c0a74c5b43c2a5fc5efd29ec63d6>:0